### PR TITLE
Avoid reflections when configuring custom BindVariableRender or TemplateEngineCustomizer.

### DIFF
--- a/src/main/asciidoc/user-guide.adoc
+++ b/src/main/asciidoc/user-guide.adoc
@@ -1038,12 +1038,12 @@ dialect.bind-variable-render = org.mybatis.scripting.thymeleaf.support.spring.Sp
 .How to customize using config class
 ----
 SqlGeneratorConfig config = SqlGeneratorConfig.newInstanceWithCustomizer(c ->
-    c.getDialect().setBindVariableRender(
-        BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER.getType())); // <1>
+    c.getDialect().setBindVariableRenderInstance(
+        BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER)); // <1>
 SqlGenerator sqlGenerator = new SqlGenerator(config); // <2>
 ----
 
-<1> Specify the `BindVariableRender` implementation class(built-in class) that render Spring JDBC bind variable format via `BuiltIn` enum
+<1> Specify the `BindVariableRender` implementation (built-in class) that renders Spring JDBC bind variable format via `BuiltIn` enum
 <2> Create a `SqlGenerator` instance with user defined configuration
 
 If you use the custom bind variable format other than built-in format,
@@ -1284,8 +1284,8 @@ dialect.bind-variable-render = org.mybatis.scripting.thymeleaf.support.spring.Sp
 .How to enable via configuration class (SqlGeneratorConfig)
 ----
 SqlGeneratorConfig config = SqlGeneratorConfig.newInstanceWithCustomizer(c ->
-    c.getDialect().setBindVariableRender(
-        BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER.getType()));
+    c.getDialect().setBindVariableRenderInstance(
+        BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER));
 SqlGenerator sqlGenerator = new SqlGenerator(config);
 ----
 
@@ -1523,7 +1523,7 @@ These properties can be specified via factory method of `ThymeleafLanguageDriver
 configuration.getLanguageRegistry().register(
   new ThymeleafLanguageDriver(ThymeleafLanguageDriverConfig.newInstance(c -> {
   c.setUse2way(false);
-  c.setCustomizer(CustomTemplateEngineCustomizer.class);
+  c.setCustomizerInstance(new CustomTemplateEngineCustomizer());
   c.getTemplateFile().setCacheEnabled(false);
   c.getTemplateFile().setCacheTtl(3600000L);
   c.getTemplateFile().setEncoding(StandardCharsets.UTF_8);
@@ -1538,8 +1538,8 @@ configuration.getLanguageRegistry().register(
   c.getDialect().setLikeEscapeChar('~');
   c.getDialect().setLikeEscapeClauseFormat("escape '%s'");
   c.getDialect().setLikeAdditionalEscapeTargetChars('％', '＿');
-  c.getDialect().setBindVariableRender(
-      BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER.getType());
+  c.getDialect().setBindVariableRenderInstance(
+      BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER);
 })));
 ----
 
@@ -1558,7 +1558,7 @@ These properties can be specified via factory method of `SqlGeneratorConfig` as 
 SqlGeneratorConfig config =
   SqlGeneratorConfig.newInstanceWithCustomizer(c -> {
   c.setUse2way(false);
-  c.setCustomizer(CustomTemplateEngineCustomizer.class);
+  c.setCustomizerInstance(new CustomTemplateEngineCustomizer());
   c.getTemplateFile().setCacheEnabled(false);
   c.getTemplateFile().setCacheTtl(3600000L);
   c.getTemplateFile().setEncoding(StandardCharsets.UTF_8);
@@ -1568,8 +1568,8 @@ SqlGeneratorConfig config =
   c.getDialect().setLikeEscapeChar('~');
   c.getDialect().setLikeEscapeClauseFormat("escape '%s'");
   c.getDialect().setLikeAdditionalEscapeTargetChars('％', '＿');
-  c.getDialect().setBindVariableRender(
-      BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER.getType());
+  c.getDialect().setBindVariableRenderInstance(
+      BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER);
 });
 // ...
 ----

--- a/src/main/java/org/mybatis/scripting/thymeleaf/SqlGenerator.java
+++ b/src/main/java/org/mybatis/scripting/thymeleaf/SqlGenerator.java
@@ -125,8 +125,7 @@ public class SqlGenerator {
 
   private ITemplateEngine createDefaultTemplateEngine(SqlGeneratorConfig config) {
     MyBatisDialect dialect = new MyBatisDialect(config.getDialect().getPrefix());
-    Optional.ofNullable(config.getDialect().getBindVariableRender()).map(SqlGeneratorConfig::newInstanceForType)
-        .ifPresent(dialect::setBindVariableRender);
+    Optional.ofNullable(config.getDialect().getBindVariableRenderInstance()).ifPresent(dialect::setBindVariableRender);
     Likes likes = Likes.newBuilder().escapeChar(config.getDialect().getLikeEscapeChar())
         .escapeClauseFormat(config.getDialect().getLikeEscapeClauseFormat())
         .additionalEscapeTargetChars(config.getDialect().getLikeAdditionalEscapeTargetChars()).build();
@@ -158,8 +157,7 @@ public class SqlGenerator {
         new MyBatisIntegratingEngineContextFactory(targetTemplateEngine.getEngineContextFactory()));
 
     // Create an TemplateEngineCustomizer instance and apply
-    Optional.ofNullable(config.getCustomizer()).map(SqlGeneratorConfig::newInstanceForType)
-        .ifPresent(x -> x.accept(targetTemplateEngine));
+    Optional.ofNullable(config.getCustomizerInstance()).ifPresent(x -> x.accept(targetTemplateEngine));
 
     return targetTemplateEngine;
   }

--- a/src/main/java/org/mybatis/scripting/thymeleaf/SqlGeneratorConfig.java
+++ b/src/main/java/org/mybatis/scripting/thymeleaf/SqlGeneratorConfig.java
@@ -76,9 +76,9 @@ public class SqlGeneratorConfig {
   private boolean use2way = true;
 
   /**
-   * The interface for customizing a default TemplateEngine instanced by the mybatis-thymeleaf.
+   * The instance for customizing a default TemplateEngine instanced by the mybatis-thymeleaf.
    */
-  private Class<? extends TemplateEngineCustomizer> customizer;
+  private TemplateEngineCustomizer customizer;
 
   /**
    * Template file configuration.
@@ -117,11 +117,14 @@ public class SqlGeneratorConfig {
    * <p>
    * Default is {@code null}.
    * </p>
+   * This method exists for the backward compatibility.<br>
+   * Use {@link #getCustomizerInstance()} instead
    *
    * @return the interface for customizing a default TemplateEngine
    */
+  @Deprecated
   public Class<? extends TemplateEngineCustomizer> getCustomizer() {
-    return customizer;
+    return customizer == null ? null : customizer.getClass();
   }
 
   /**
@@ -130,7 +133,16 @@ public class SqlGeneratorConfig {
    * @param customizer
    *          the interface for customizing a default TemplateEngine
    */
+  @Deprecated
   public void setCustomizer(Class<? extends TemplateEngineCustomizer> customizer) {
+    this.customizer = newInstanceForType(customizer);
+  }
+
+  public TemplateEngineCustomizer getCustomizerInstance() {
+    return customizer;
+  }
+
+  public void setCustomizerInstance(TemplateEngineCustomizer customizer) {
     this.customizer = customizer;
   }
 
@@ -328,7 +340,7 @@ public class SqlGeneratorConfig {
     /**
      * The bind variable render.
      */
-    private Class<? extends BindVariableRender> bindVariableRender;
+    private BindVariableRender bindVariableRender;
 
     /**
      * Get the prefix name of dialect provided by this project.
@@ -423,17 +435,35 @@ public class SqlGeneratorConfig {
      * <p>
      * Default is {@link BindVariableRender.BuiltIn#MYBATIS}
      * </p>
+     * This method exists for the backward compatibility. <br>
+     * Use {@link #getBindVariableRenderInstance()} instead
      *
      * @return a bind variable render
      */
+    @Deprecated
     public Class<? extends BindVariableRender> getBindVariableRender() {
+      return bindVariableRender == null ? null : bindVariableRender.getClass();
+    }
+
+    /**
+     * This method exists for the backward compatibility.<br>
+     * Use {@link #setBindVariableRenderInstance(BindVariableRender)} instead
+     *
+     * @param bindVariableRender
+     *          bindVariableRender class
+     */
+    @Deprecated
+    public void setBindVariableRender(Class<? extends BindVariableRender> bindVariableRender) {
+      this.bindVariableRender = newInstanceForType(bindVariableRender);
+    }
+
+    public BindVariableRender getBindVariableRenderInstance() {
       return bindVariableRender;
     }
 
-    public void setBindVariableRender(Class<? extends BindVariableRender> bindVariableRender) {
+    public void setBindVariableRenderInstance(BindVariableRender bindVariableRender) {
       this.bindVariableRender = bindVariableRender;
     }
-
   }
 
   /**

--- a/src/test/java/org/mybatis/scripting/thymeleaf/SqlGeneratorTest.java
+++ b/src/test/java/org/mybatis/scripting/thymeleaf/SqlGeneratorTest.java
@@ -65,7 +65,7 @@ class SqlGeneratorTest {
       }
     }
     config = SqlGeneratorConfig.newInstanceWithCustomizer(
-        c -> c.getDialect().setBindVariableRender(BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER.getType()));
+        c -> c.getDialect().setBindVariableRenderInstance(BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER));
   }
 
   @Test
@@ -95,7 +95,7 @@ class SqlGeneratorTest {
   @Test
   void processWithConfig() {
     SqlGeneratorConfig config = SqlGeneratorConfig.newInstanceWithCustomizer(
-        c -> c.getDialect().setBindVariableRender(BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER.getType()));
+        c -> c.getDialect().setBindVariableRenderInstance(BindVariableRender.BuiltIn.SPRING_NAMED_PARAMETER));
     SqlGenerator sqlGenerator = new SqlGenerator(config);
     NamedParameterJdbcOperations jdbcOperations = new NamedParameterJdbcTemplate(dataSource);
 

--- a/src/test/java/org/mybatis/scripting/thymeleaf/ThymeleafLanguageDriverTest.java
+++ b/src/test/java/org/mybatis/scripting/thymeleaf/ThymeleafLanguageDriverTest.java
@@ -236,7 +236,7 @@ class ThymeleafLanguageDriverTest {
     System.setProperty("mybatis-thymeleaf.config.file", "mybatis-thymeleaf-empty.properties");
     ThymeleafLanguageDriverConfig thymeleafLanguageDriverConfig = ThymeleafLanguageDriverConfig.newInstance(c -> {
       c.setUse2way(false);
-      c.setCustomizer(CustomTemplateEngineCustomizer.class);
+      c.setCustomizerInstance(new CustomTemplateEngineCustomizer());
       c.getTemplateFile().setCacheEnabled(false);
       c.getTemplateFile().setCacheTtl(30000L);
       c.getTemplateFile().setEncoding(StandardCharsets.ISO_8859_1);
@@ -406,7 +406,8 @@ class ThymeleafLanguageDriverTest {
       Assertions.assertEquals(
           "Failed to load language driver for org.mybatis.scripting.thymeleaf.ThymeleafLanguageDriver", e.getMessage());
       // Since mybatis 3.5.1, exception is wrapped by InvocationTargetException
-      Throwable cause = e.getCause() instanceof InvocationTargetException ? e.getCause().getCause() : e.getCause();
+      Throwable cause = e.getCause() instanceof InvocationTargetException
+          ? e.getCause().getCause().getCause().getCause() : e.getCause();
       Assertions.assertEquals(
           "Cannot create an instance for class: class org.mybatis.scripting.thymeleaf.NoDefaultConstructorTemplateEngineCustomizer",
           cause.getMessage());


### PR DESCRIPTION
Using reflection in JavaConfig doesn't make sense and it can be a penalty when creating a native image with GraalVM